### PR TITLE
[STACCMR-39] Create Collections Module

### DIFF
--- a/search/lib/cmr/cmr_converter.js
+++ b/search/lib/cmr/cmr_converter.js
@@ -3,97 +3,11 @@ const { parseOrdinateString } = require('../../lib/convert/bounding-box');
 const { wfs, generateAppUrl, extractParam, generateSelfUrl } = require('../util');
 const cmr = require('./cmr');
 
-const WHOLE_WORLD_BBOX = [-180, 90, 180, -90]; // add this to the collection file
-
-// TODO this needs to be tested
-
 // move to collection_converter
-const cmrCollSpatialToExtents = (cmrColl) => {
-  let bbox = null;
-  if (cmrColl.polygons) {
-    // an array of arrays of strings containing rings
-    // [["lat1 lon1 lat2 lon2 ..."]]
-    // In the inner most array all you need is the first string. That's the outer boundary
-    bbox = cmrColl.polygons
-      .map((rings) => rings[0])
-      .map(pointStringToPoints)
-      .reduce(addPointsToBbox, bbox);
-  }
-  if (cmrColl.points) {
-    // an array of strings of "lat lon"
-    // [ "53.63 -106.2"
-    const points = cmrColl.points.map(parseOrdinateString);
-    bbox = addPointsToBbox(bbox, points);
-  }
-  if (cmrColl.lines) {
-    throw new Error(`Unepxected spatial extent of lines in ${cmrColl.id}`);
-  }
-  if (cmrColl.boxes) {
-    // a list of strings of south west north east
-    // TODO can cross antimeridian
-    // [ "-14.3601 -176.6525 64.823 151.78372" ]
-
-    bbox = cmrColl.boxes.reduce((box, boxStr) => mergeBoxes(box, parseOrdinateString(boxStr)), bbox);
-  }
-  if (_.isNull(bbox)) {
-    // whole world bbox
-    bbox = WHOLE_WORLD_BBOX;
-  }
-  return bbox;
-};
 
 // TODO remove page_num params from these
 
 // Move to collection_converter
-const stacSearchWithCurrentParams = (event, collId) => {
-  const newParams = [...event.queryStringParameters] || {};
-  newParams.collectionId = collId;
-  // The provider param isn't needed once the colleciton id is set.
-  delete newParams.provider;
-  return generateAppUrl(event, '/search/stac', newParams);
-};
-
-// Move to collection_converter
-const cmrGranuleSearchWithCurrentParams = (event, collId) => {
-  const newParams = [...event.queryStringParameters] || {};
-  newParams.collection_concept_id = collId;
-  // The provider param isn't needed once the colleciton id is set.
-  delete newParams.collectionId;
-  delete newParams.provider;
-  return cmr.makeCmrSearchUrl('granules.json', newParams);
-};
-
-// Move to collection_converter
-const cmrCollToWFSColl = (event, cmrColl) => ({
-  name: cmrColl.id,
-  title: cmrColl.dataset_id,
-  description: cmrColl.summary,
-  links: [
-    wfs.createLink('self', generateAppUrl(event, `/collections/${cmrColl.id}`),
-      'Info about this collection'),
-    wfs.createLink('stac', stacSearchWithCurrentParams(event, cmrColl.id),
-      'STAC Search this collection'),
-    wfs.createLink('cmr', cmrGranuleSearchWithCurrentParams(event, cmrColl.id),
-      'CMR Search this collection'),
-    wfs.createLink('items', generateAppUrl(event, `/collections/${cmrColl.id}/items`),
-      'Granules in this collection'),
-    wfs.createLink('overview', cmr.makeCmrSearchUrl(`/concepts/${cmrColl.id}.html`),
-      'HTML metadata for collection'),
-    wfs.createLink('metadata', cmr.makeCmrSearchUrl(`/concepts/${cmrColl.id}.native`),
-      'Native metadata for collection'),
-    wfs.createLink('metadata', cmr.makeCmrSearchUrl(`/concepts/${cmrColl.id}.umm_json`),
-      'JSON metadata for collection')
-  ],
-  extent: {
-    crs: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84',
-    spatial: cmrCollSpatialToExtents(cmrColl),
-    trs: 'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian',
-    temporal: [
-      cmrColl.time_start,
-      (cmrColl.time_end || cmrColl.time_start)
-    ]
-  }
-});
 
 // Move to granule_to_item
 const cmrPolygonToGeoJsonPolygon = (polygon) => {
@@ -209,24 +123,6 @@ const cmrGranToFeatureGeoJSON = (event, cmrGran) => {
       datetime
     },
     assets
-  };
-};
-
-// Move to collection_converter?
-const cmrGranulesToFeatureCollection = (event, cmrGrans) => {
-  const currPage = parseInt(extractParam(event.queryStringParameters, 'page_num', '1'), 10);
-  const nextPage = currPage + 1;
-  const newParams = { ...event.queryStringParameters } || {};
-  newParams.page_num = nextPage;
-  const nextResultsLink = generateAppUrl(event, event.path, newParams);
-
-  return {
-    type: 'FeatureCollection',
-    features: cmrGrans.map(g => cmrGranToFeatureGeoJSON(event, g)),
-    links: {
-      self: generateSelfUrl(event),
-      next: nextResultsLink
-    }
   };
 };
 

--- a/search/lib/cmr/cmr_converter.js
+++ b/search/lib/cmr/cmr_converter.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const { parseOrdinateString, pointStringToPoints, cmrCollSpatialToExtents } = require('../convert');
+const { pointStringToPoints, cmrCollSpatialToExtents } = require('../convert');
 const { wfs, generateAppUrl } = require('../util');
 const cmr = require('./cmr');
 
@@ -44,6 +44,8 @@ const cmrSpatialToGeoJSONGeometry = (cmrGran) => {
   }
   if (cmrGran.points) {
     geometry = geometry.concat(cmrGran.points.map((ps) => {
+      const { parseOrdinateString } = require('../convert');
+
       const [lat, lon] = parseOrdinateString(ps);
       return { type: 'Point', coordinates: [lon, lat] };
     }));

--- a/search/lib/cmr/cmr_converter.js
+++ b/search/lib/cmr/cmr_converter.js
@@ -1,6 +1,5 @@
 const _ = require('lodash');
-const { parseOrdinateString, pointStringToPoints } = require('../../lib/convert/bounding-box');
-const { cmrCollSpatialToExtents } = require('../../lib/convert/collections');
+const { parseOrdinateString, pointStringToPoints, cmrCollSpatialToExtents } = require('../../lib/convert/');
 const { wfs, generateAppUrl } = require('../util');
 const cmr = require('./cmr');
 

--- a/search/lib/cmr/cmr_converter.js
+++ b/search/lib/cmr/cmr_converter.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const { parseOrdinateString, pointStringToPoints, cmrCollSpatialToExtents } = require('../../lib/convert/');
+const { parseOrdinateString, pointStringToPoints, cmrCollSpatialToExtents } = require('../convert');
 const { wfs, generateAppUrl } = require('../util');
 const cmr = require('./cmr');
 

--- a/search/lib/cmr/cmr_converter.js
+++ b/search/lib/cmr/cmr_converter.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
-const { parseOrdinateString } = require('../../lib/convert/bounding-box');
-const { wfs, generateAppUrl, extractParam, generateSelfUrl } = require('../util');
+const { parseOrdinateString, pointStringToPoints } = require('../../lib/convert/bounding-box');
+const { cmrCollSpatialToExtents } = require('../../lib/convert/collections');
+const { wfs, generateAppUrl } = require('../util');
 const cmr = require('./cmr');
 
 // move to collection_converter
@@ -127,10 +128,7 @@ const cmrGranToFeatureGeoJSON = (event, cmrGran) => {
 };
 
 module.exports = {
-  cmrCollToWFSColl,
   cmrGranToFeatureGeoJSON,
-  cmrGranulesToFeatureCollection,
-  // parseOrdinateString,
   // For testing
   _private: {
     cmrCollSpatialToExtents

--- a/search/lib/convert/collections.js
+++ b/search/lib/convert/collections.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const cmr = require('./cmr');
+const cmr = require('../cmr/cmr');
 const { wfs, generateAppUrl, extractParam, generateSelfUrl } = require('../util');
 const { WHOLE_WORLD_BBOX, pointStringToPoints, parseOrdinateString, addPointsToBbox, mergeBoxes } = require('./bounding-box');
 const { cmrGranToFeatureGeoJSON } = require('../cmr/cmr_converter');

--- a/search/lib/convert/collections.js
+++ b/search/lib/convert/collections.js
@@ -1,0 +1,101 @@
+const WHOLE_WORLD_BBOX = require('./bounding-box');
+
+const cmrCollSpatialToExtents = (cmrColl) => {
+  let bbox = null;
+  if (cmrColl.polygons) {
+    // an array of arrays of strings containing rings
+    // [["lat1 lon1 lat2 lon2 ..."]]
+    // In the inner most array all you need is the first string. That's the outer boundary
+    bbox = cmrColl.polygons
+      .map((rings) => rings[0])
+      .map(pointStringToPoints)
+      .reduce(addPointsToBbox, bbox);
+  }
+  if (cmrColl.points) {
+    // an array of strings of "lat lon"
+    // [ "53.63 -106.2"
+    const points = cmrColl.points.map(parseOrdinateString);
+    bbox = addPointsToBbox(bbox, points);
+  }
+  if (cmrColl.lines) {
+    throw new Error(`Unepxected spatial extent of lines in ${cmrColl.id}`);
+  }
+  if (cmrColl.boxes) {
+    // a list of strings of south west north east
+    // TODO can cross antimeridian
+    // [ "-14.3601 -176.6525 64.823 151.78372" ]
+
+    bbox = cmrColl.boxes.reduce((box, boxStr) => mergeBoxes(box, parseOrdinateString(boxStr)), bbox);
+  }
+  if (_.isNull(bbox)) {
+    // whole world bbox
+    bbox = WHOLE_WORLD_BBOX;
+  }
+  return bbox;
+};
+
+const stacSearchWithCurrentParams = (event, collId) => {
+  const newParams = [...event.queryStringParameters] || {};
+  newParams.collectionId = collId;
+  // The provider param isn't needed once the colleciton id is set.
+  delete newParams.provider;
+  return generateAppUrl(event, '/search/stac', newParams);
+};
+
+const cmrGranuleSearchWithCurrentParams = (event, collId) => {
+  const newParams = [...event.queryStringParameters] || {};
+  newParams.collection_concept_id = collId;
+  // The provider param isn't needed once the colleciton id is set.
+  delete newParams.collectionId;
+  delete newParams.provider;
+  return cmr.makeCmrSearchUrl('granules.json', newParams);
+};
+
+const cmrCollToWFSColl = (event, cmrColl) => ({
+  name: cmrColl.id,
+  title: cmrColl.dataset_id,
+  description: cmrColl.summary,
+  links: [
+    wfs.createLink('self', generateAppUrl(event, `/collections/${cmrColl.id}`),
+      'Info about this collection'),
+    wfs.createLink('stac', stacSearchWithCurrentParams(event, cmrColl.id),
+      'STAC Search this collection'),
+    wfs.createLink('cmr', cmrGranuleSearchWithCurrentParams(event, cmrColl.id),
+      'CMR Search this collection'),
+    wfs.createLink('items', generateAppUrl(event, `/collections/${cmrColl.id}/items`),
+      'Granules in this collection'),
+    wfs.createLink('overview', cmr.makeCmrSearchUrl(`/concepts/${cmrColl.id}.html`),
+      'HTML metadata for collection'),
+    wfs.createLink('metadata', cmr.makeCmrSearchUrl(`/concepts/${cmrColl.id}.native`),
+      'Native metadata for collection'),
+    wfs.createLink('metadata', cmr.makeCmrSearchUrl(`/concepts/${cmrColl.id}.umm_json`),
+      'JSON metadata for collection')
+  ],
+  extent: {
+    crs: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84',
+    spatial: cmrCollSpatialToExtents(cmrColl),
+    trs: 'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian',
+    temporal: [
+      cmrColl.time_start,
+      (cmrColl.time_end || cmrColl.time_start)
+    ]
+  }
+});
+
+// Move to collection_converter?
+const cmrGranulesToFeatureCollection = (event, cmrGrans) => {
+  const currPage = parseInt(extractParam(event.queryStringParameters, 'page_num', '1'), 10);
+  const nextPage = currPage + 1;
+  const newParams = { ...event.queryStringParameters } || {};
+  newParams.page_num = nextPage;
+  const nextResultsLink = generateAppUrl(event, event.path, newParams);
+
+  return {
+    type: 'FeatureCollection',
+    features: cmrGrans.map(g => cmrGranToFeatureGeoJSON(event, g)),
+    links: {
+      self: generateSelfUrl(event),
+      next: nextResultsLink
+    }
+  };
+};

--- a/search/lib/convert/collections.js
+++ b/search/lib/convert/collections.js
@@ -1,9 +1,8 @@
 const _ = require('lodash');
 const cmr = require('./cmr');
-const { parseOrdinateString } = require('../../lib/convert/bounding-box');
 const { wfs, generateAppUrl, extractParam, generateSelfUrl } = require('../util');
-const { WHOLE_WORLD_BBOX, pointStringToPoints, addPointsToBbox, mergeBoxes } = require('./bounding-box');
-const {cmrGranToFeatureGeoJSON} = require('../cmr/cmr_converter')
+const { WHOLE_WORLD_BBOX, pointStringToPoints, parseOrdinateString, addPointsToBbox, mergeBoxes } = require('./bounding-box');
+const { cmrGranToFeatureGeoJSON } = require('../cmr/cmr_converter');
 
 const cmrCollSpatialToExtents = (cmrColl) => {
   let bbox = null;

--- a/search/lib/convert/collections.js
+++ b/search/lib/convert/collections.js
@@ -1,10 +1,8 @@
-const _ = require('lodash');
 const cmr = require('../cmr/cmr');
-const { wfs, generateAppUrl, extractParam, generateSelfUrl } = require('../util');
+const { wfs, generateAppUrl } = require('../util');
 const { WHOLE_WORLD_BBOX, pointStringToPoints, parseOrdinateString, addPointsToBbox, mergeBoxes } = require('./bounding-box');
-const { cmrGranToFeatureGeoJSON } = require('../cmr/cmr_converter');
 
-const cmrCollSpatialToExtents = (cmrColl) => {
+function cmrCollSpatialToExtents (cmrColl) {
   let bbox = null;
   if (cmrColl.polygons) {
     // an array of arrays of strings containing rings
@@ -17,7 +15,7 @@ const cmrCollSpatialToExtents = (cmrColl) => {
   }
   if (cmrColl.points) {
     // an array of strings of "lat lon"
-    // [ "53.63 -106.2"
+    // [ "53.63 -106.2", "33 -145"]
     const points = cmrColl.points.map(parseOrdinateString);
     bbox = addPointsToBbox(bbox, points);
   }
@@ -25,20 +23,20 @@ const cmrCollSpatialToExtents = (cmrColl) => {
     throw new Error(`Unepxected spatial extent of lines in ${cmrColl.id}`);
   }
   if (cmrColl.boxes) {
-    // a list of strings of south west north east
+    // a list of strings of west north east south
     // TODO can cross antimeridian
     // [ "-14.3601 -176.6525 64.823 151.78372" ]
 
     bbox = cmrColl.boxes.reduce((box, boxStr) => mergeBoxes(box, parseOrdinateString(boxStr)), bbox);
   }
-  if (_.isNull(bbox)) {
+  if (bbox === null) {
     // whole world bbox
     bbox = WHOLE_WORLD_BBOX;
   }
   return bbox;
 };
 
-const stacSearchWithCurrentParams = (event, collId) => {
+function stacSearchWithCurrentParams (event, collId) {
   const newParams = [...event.queryStringParameters] || {};
   newParams.collectionId = collId;
   // The provider param isn't needed once the colleciton id is set.
@@ -46,7 +44,7 @@ const stacSearchWithCurrentParams = (event, collId) => {
   return generateAppUrl(event, '/search/stac', newParams);
 };
 
-const cmrGranuleSearchWithCurrentParams = (event, collId) => {
+function cmrGranuleSearchWithCurrentParams (event, collId) {
   const newParams = [...event.queryStringParameters] || {};
   newParams.collection_concept_id = collId;
   // The provider param isn't needed once the colleciton id is set.
@@ -86,28 +84,9 @@ const cmrCollToWFSColl = (event, cmrColl) => ({
   }
 });
 
-// Move to collection_converter?
-const cmrGranulesToFeatureCollection = (event, cmrGrans) => {
-  const currPage = parseInt(extractParam(event.queryStringParameters, 'page_num', '1'), 10);
-  const nextPage = currPage + 1;
-  const newParams = { ...event.queryStringParameters } || {};
-  newParams.page_num = nextPage;
-  const nextResultsLink = generateAppUrl(event, event.path, newParams);
-
-  return {
-    type: 'FeatureCollection',
-    features: cmrGrans.map(g => cmrGranToFeatureGeoJSON(event, g)),
-    links: {
-      self: generateSelfUrl(event),
-      next: nextResultsLink
-    }
-  };
-};
-
 module.exports = {
   cmrCollSpatialToExtents,
   stacSearchWithCurrentParams,
   cmrGranuleSearchWithCurrentParams,
-  cmrCollToWFSColl,
-  cmrGranulesToFeatureCollection
+  cmrCollToWFSColl
 };

--- a/search/lib/convert/collections.js
+++ b/search/lib/convert/collections.js
@@ -34,7 +34,7 @@ function cmrCollSpatialToExtents (cmrColl) {
     bbox = WHOLE_WORLD_BBOX;
   }
   return bbox;
-};
+}
 
 function stacSearchWithCurrentParams (event, collId) {
   const newParams = [...event.queryStringParameters] || {};
@@ -42,7 +42,7 @@ function stacSearchWithCurrentParams (event, collId) {
   // The provider param isn't needed once the colleciton id is set.
   delete newParams.provider;
   return generateAppUrl(event, '/search/stac', newParams);
-};
+}
 
 function cmrGranuleSearchWithCurrentParams (event, collId) {
   const newParams = [...event.queryStringParameters] || {};
@@ -51,7 +51,7 @@ function cmrGranuleSearchWithCurrentParams (event, collId) {
   delete newParams.collectionId;
   delete newParams.provider;
   return cmr.makeCmrSearchUrl('granules.json', newParams);
-};
+}
 
 const cmrCollToWFSColl = (event, cmrColl) => ({
   name: cmrColl.id,

--- a/search/lib/convert/collections.js
+++ b/search/lib/convert/collections.js
@@ -37,15 +37,15 @@ function cmrCollSpatialToExtents (cmrColl) {
 }
 
 function stacSearchWithCurrentParams (event, collId) {
-  const newParams = [...event.queryStringParameters] || {};
+  const newParams = { ...event.queryStringParameters } || {};
   newParams.collectionId = collId;
   // The provider param isn't needed once the colleciton id is set.
   delete newParams.provider;
-  return generateAppUrl(event, '/search/stac', newParams);
+  return generateAppUrl(event, 'search/stac', newParams);
 }
 
 function cmrGranuleSearchWithCurrentParams (event, collId) {
-  const newParams = [...event.queryStringParameters] || {};
+  const newParams = { ...event.queryStringParameters } || {};
   newParams.collection_concept_id = collId;
   // The provider param isn't needed once the colleciton id is set.
   delete newParams.collectionId;
@@ -53,36 +53,38 @@ function cmrGranuleSearchWithCurrentParams (event, collId) {
   return cmr.makeCmrSearchUrl('granules.json', newParams);
 }
 
-const cmrCollToWFSColl = (event, cmrColl) => ({
-  name: cmrColl.id,
-  title: cmrColl.dataset_id,
-  description: cmrColl.summary,
-  links: [
-    wfs.createLink('self', generateAppUrl(event, `/collections/${cmrColl.id}`),
-      'Info about this collection'),
-    wfs.createLink('stac', stacSearchWithCurrentParams(event, cmrColl.id),
-      'STAC Search this collection'),
-    wfs.createLink('cmr', cmrGranuleSearchWithCurrentParams(event, cmrColl.id),
-      'CMR Search this collection'),
-    wfs.createLink('items', generateAppUrl(event, `/collections/${cmrColl.id}/items`),
-      'Granules in this collection'),
-    wfs.createLink('overview', cmr.makeCmrSearchUrl(`/concepts/${cmrColl.id}.html`),
-      'HTML metadata for collection'),
-    wfs.createLink('metadata', cmr.makeCmrSearchUrl(`/concepts/${cmrColl.id}.native`),
-      'Native metadata for collection'),
-    wfs.createLink('metadata', cmr.makeCmrSearchUrl(`/concepts/${cmrColl.id}.umm_json`),
-      'JSON metadata for collection')
-  ],
-  extent: {
-    crs: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84',
-    spatial: cmrCollSpatialToExtents(cmrColl),
-    trs: 'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian',
-    temporal: [
-      cmrColl.time_start,
-      (cmrColl.time_end || cmrColl.time_start)
-    ]
-  }
-});
+function cmrCollToWFSColl (event, cmrColl) {
+  return ({
+    name: cmrColl.id,
+    title: cmrColl.dataset_id,
+    description: cmrColl.summary,
+    links: [
+      wfs.createLink('self', generateAppUrl(event, `/collections/${cmrColl.id}`),
+        'Info about this collection'),
+      wfs.createLink('stac', stacSearchWithCurrentParams(event, cmrColl.id),
+        'STAC Search this collection'),
+      wfs.createLink('cmr', cmrGranuleSearchWithCurrentParams(event, cmrColl.id),
+        'CMR Search this collection'),
+      wfs.createLink('items', generateAppUrl(event, `/collections/${cmrColl.id}/items`),
+        'Granules in this collection'),
+      wfs.createLink('overview', cmr.makeCmrSearchUrl(`/concepts/${cmrColl.id}.html`),
+        'HTML metadata for collection'),
+      wfs.createLink('metadata', cmr.makeCmrSearchUrl(`/concepts/${cmrColl.id}.native`),
+        'Native metadata for collection'),
+      wfs.createLink('metadata', cmr.makeCmrSearchUrl(`/concepts/${cmrColl.id}.umm_json`),
+        'JSON metadata for collection')
+    ],
+    extent: {
+      crs: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84',
+      spatial: cmrCollSpatialToExtents(cmrColl),
+      trs: 'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian',
+      temporal: [
+        cmrColl.time_start,
+        (cmrColl.time_end || cmrColl.time_start)
+      ]
+    }
+  });
+}
 
 module.exports = {
   cmrCollSpatialToExtents,

--- a/search/lib/convert/collections.js
+++ b/search/lib/convert/collections.js
@@ -1,4 +1,9 @@
-const WHOLE_WORLD_BBOX = require('./bounding-box');
+const _ = require('lodash');
+const cmr = require('./cmr');
+const { parseOrdinateString } = require('../../lib/convert/bounding-box');
+const { wfs, generateAppUrl, extractParam, generateSelfUrl } = require('../util');
+const { WHOLE_WORLD_BBOX, pointStringToPoints, addPointsToBbox, mergeBoxes } = require('./bounding-box');
+const {cmrGranToFeatureGeoJSON} = require('../cmr/cmr_converter')
 
 const cmrCollSpatialToExtents = (cmrColl) => {
   let bbox = null;
@@ -98,4 +103,12 @@ const cmrGranulesToFeatureCollection = (event, cmrGrans) => {
       next: nextResultsLink
     }
   };
+};
+
+module.exports = {
+  cmrCollSpatialToExtents,
+  stacSearchWithCurrentParams,
+  cmrGranuleSearchWithCurrentParams,
+  cmrCollToWFSColl,
+  cmrGranulesToFeatureCollection
 };

--- a/search/lib/convert/index.js
+++ b/search/lib/convert/index.js
@@ -1,7 +1,6 @@
 const boundingBox = require('./bounding-box');
 const collections = require('./collections');
+const { inspect } = require('util');
 
-module.export = {
-  ...boundingBox,
-  ...collections
-};
+console.log(inspect(boundingBox));
+module.exports = Object.assign({}, boundingBox, collections);

--- a/search/lib/convert/index.js
+++ b/search/lib/convert/index.js
@@ -1,4 +1,7 @@
 const boundingBox = require('./bounding-box');
 const collections = require('./collections');
 
-module.exports = Object.assign({}, boundingBox, collections);
+module.exports = {
+  ...boundingBox,
+  ...collections
+};

--- a/search/lib/convert/index.js
+++ b/search/lib/convert/index.js
@@ -1,5 +1,7 @@
 const boundingBox = require('./bounding-box');
+const collections = require('./collections');
 
 module.export = {
-  boundingBox
+  ...boundingBox,
+  ...collections
 };

--- a/search/lib/convert/index.js
+++ b/search/lib/convert/index.js
@@ -1,6 +1,4 @@
 const boundingBox = require('./bounding-box');
 const collections = require('./collections');
-const { inspect } = require('util');
 
-console.log(inspect(boundingBox));
 module.exports = Object.assign({}, boundingBox, collections);

--- a/search/tests/cmr/cmr_converter.spec.js
+++ b/search/tests/cmr/cmr_converter.spec.js
@@ -1,9 +1,9 @@
-const { parseOrdinateString } = require('../../lib/convert/bounding-box');
 const {
   cmrCollToWFSColl,
-  cmrGranToFeatureGeoJSON,
-  cmrGranulesToFeatureCollection
-} = require('../../lib/cmr/cmr_converter');
+  parseOrdinateString
+} = require('../../lib/convert');
+
+const { cmrGranToFeatureGeoJSON } = require('../../lib/cmr/cmr_converter');
 
 describe('cmrCollToWFSCol', () => {
   const cmrColl = {
@@ -123,65 +123,6 @@ describe('cmrGranToFeatureGeoJSON', () => {
           type: 'application/json',
           title: undefined
         }
-      }
-    });
-  });
-});
-
-describe('cmrGranulesToFeatureCollection', () => {
-  const cmrGran = [{
-    id: 1,
-    collection_concept_id: 10,
-    dataset_id: 'datasetId',
-    summary: 'summary',
-    time_start: 0,
-    time_end: 1,
-    links: [
-      {
-        href: 'http://example.com/collections/id',
-        rel: 'self',
-        title: 'Info about this collection',
-        type: 'application/json'
-      }
-    ],
-    data_center: 'USA',
-    points: ['39,77']
-  }];
-
-  const event = { headers: { Host: 'example.com' }, queryStringParameters: [] };
-
-  it('should return a cmrGranule to a FeatureCollection', () => {
-    expect(cmrGranulesToFeatureCollection(event, cmrGran)).toEqual({
-      type: 'FeatureCollection',
-      features: [{
-        id: 1,
-        geometry: { type: 'Point', coordinates: [77, 39] },
-        properties: {
-          provider: 'USA',
-          datetime: '0/1'
-        },
-        type: 'Feature',
-        assets: {},
-        links: {
-          self: {
-            rel: 'self',
-            href: 'http://example.com/collections/10/items/1'
-          },
-          parent: {
-            rel: 'parent',
-            href: 'http://example.com/collections/10'
-          },
-          metadata: {
-            href: 'https://cmr.earthdata.nasa.gov/search/concepts/1.native',
-            rel: 'metadata',
-            type: 'application/json',
-            title: undefined
-          }
-        }
-      }],
-      links: {
-        self: 'http://example.com/undefined?',
-        next: 'http://example.com/undefined?page_num=2'
       }
     });
   });

--- a/search/tests/cmr/cmr_converter.spec.js
+++ b/search/tests/cmr/cmr_converter.spec.js
@@ -3,6 +3,8 @@ const {
   parseOrdinateString
 } = require('../../lib/convert');
 
+const { cmrGranulesToFeatureCollection } = require('../../lib/cmr/cmr_converter');
+
 const { cmrGranToFeatureGeoJSON } = require('../../lib/cmr/cmr_converter');
 
 describe('cmrCollToWFSCol', () => {
@@ -137,5 +139,64 @@ describe('parseOrdinateString', () => {
 
   it('should ignore separated non-number string tokens.', () => {
     expect(parseOrdinateString('1,2.1,a')).toEqual([1, 2.1, NaN]);
+  });
+});
+
+describe('cmrGranulesToFeatureCollection', () => {
+  const cmrGran = [{
+    id: 1,
+    collection_concept_id: 10,
+    dataset_id: 'datasetId',
+    summary: 'summary',
+    time_start: 0,
+    time_end: 1,
+    links: [
+      {
+        href: 'http://example.com/collections/id',
+        rel: 'self',
+        title: 'Info about this collection',
+        type: 'application/json'
+      }
+    ],
+    data_center: 'USA',
+    points: ['39,77']
+  }];
+
+  const event = { headers: { Host: 'example.com' }, queryStringParameters: [] };
+
+  it('should return a cmrGranule to a FeatureCollection', () => {
+    expect(cmrGranulesToFeatureCollection(event, cmrGran)).toEqual({
+      type: 'FeatureCollection',
+      features: [{
+        id: 1,
+        geometry: { type: 'Point', coordinates: [77, 39] },
+        properties: {
+          provider: 'USA',
+          datetime: '0/1'
+        },
+        type: 'Feature',
+        assets: {},
+        links: {
+          self: {
+            rel: 'self',
+            href: 'http://example.com/collections/10/items/1'
+          },
+          parent: {
+            rel: 'parent',
+            href: 'http://example.com/collections/10'
+          },
+          metadata: {
+            href: 'https://cmr.earthdata.nasa.gov/search/concepts/1.native',
+            rel: 'metadata',
+            type: 'application/json',
+            title: undefined
+          }
+        }
+      }],
+      links: {
+        self: 'http://example.com/undefined?',
+        next: 'http://example.com/undefined?page_num=2'
+      }
+    });
   });
 });

--- a/search/tests/cmr/cmr_converter.spec.js
+++ b/search/tests/cmr/cmr_converter.spec.js
@@ -1,82 +1,10 @@
 const {
-  cmrCollToWFSColl,
   parseOrdinateString
 } = require('../../lib/convert');
 
 const { cmrGranulesToFeatureCollection } = require('../../lib/cmr/cmr_converter');
 
 const { cmrGranToFeatureGeoJSON } = require('../../lib/cmr/cmr_converter');
-
-describe('cmrCollToWFSCol', () => {
-  const cmrColl = {
-    id: 'id',
-    dataset_id: 'datasetId',
-    summary: 'summary',
-    time_start: 0,
-    time_end: 1
-  };
-
-  const event = { headers: { Host: 'example.com' }, queryStringParameters: [] };
-
-  it('should return a WFS Collection from a CMR collection.', () => {
-    expect(cmrCollToWFSColl(event, cmrColl)).toEqual({
-      description: 'summary',
-      extent: {
-        crs: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84',
-        spatial: [
-          -180,
-          90,
-          180,
-          -90
-        ],
-        temporal: [
-          0,
-          1
-        ],
-        trs: 'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian'
-      },
-      links: [
-        {
-          href: 'http://example.com/collections/id',
-          rel: 'self',
-          title: 'Info about this collection',
-          type: 'application/json'
-        }, {
-          href: 'http://example.com/search/stac?collectionId=id',
-          rel: 'stac',
-          title: 'STAC Search this collection',
-          type: 'application/json'
-        }, {
-          href: 'https://cmr.earthdata.nasa.gov/search/granules.json?collection_concept_id=id',
-          rel: 'cmr',
-          title: 'CMR Search this collection',
-          type: 'application/json'
-        }, {
-          href: 'http://example.com/collections/id/items',
-          rel: 'items',
-          title: 'Granules in this collection',
-          type: 'application/json'
-        }, {
-          href: 'https://cmr.earthdata.nasa.gov/search/concepts/id.html',
-          rel: 'overview',
-          title: 'HTML metadata for collection',
-          type: 'application/json'
-        }, {
-          href: 'https://cmr.earthdata.nasa.gov/search/concepts/id.native',
-          rel: 'metadata',
-          title: 'Native metadata for collection',
-          type: 'application/json'
-        }, {
-          href: 'https://cmr.earthdata.nasa.gov/search/concepts/id.umm_json',
-          rel: 'metadata',
-          title: 'JSON metadata for collection',
-          type: 'application/json'
-        }
-      ],
-      name: 'id',
-      title: 'datasetId' });
-  });
-});
 
 describe('cmrGranToFeatureGeoJSON', () => {
   const cmrGran = {

--- a/search/tests/convert/bounding-box.spec.js
+++ b/search/tests/convert/bounding-box.spec.js
@@ -1,14 +1,13 @@
 const { addPointsToBbox, mergeBoxes } = require('../../lib/convert/bounding-box');
 
 describe('bbox', () => {
-  let testBbox = [-10, 10, 10, -10];
-  let testBbox2 = [-20, 7, 44, 10]
-  let points = [[20, 100], [5, -5]];
-  let lotsOfPoints = [[20, 100], [5, -5], [-40, 73]];
+  const testBbox = [-10, 10, 10, -10];
+  const testBbox2 = [-20, 7, 44, 10];
+  const points = [[20, 100], [5, -5]];
+  const lotsOfPoints = [[20, 100], [5, -5], [-40, 73]];
   const WHOLE_WORLD_BBOX = [-180, 90, 180, -90];
 
   describe('addPointsToBbox', () => {
-
     it('should create the largest bbox', () => {
       expect(addPointsToBbox(testBbox, points)).toEqual([-10, 20, 100, -10]);
     });

--- a/search/tests/convert/collections.spec.js
+++ b/search/tests/convert/collections.spec.js
@@ -1,0 +1,60 @@
+const { cmrGranulesToFeatureCollection } = require('../../lib/convert');
+
+describe('cmrGranulesToFeatureCollection', () => {
+  const cmrGran = [{
+    id: 1,
+    collection_concept_id: 10,
+    dataset_id: 'datasetId',
+    summary: 'summary',
+    time_start: 0,
+    time_end: 1,
+    links: [
+      {
+        href: 'http://example.com/collections/id',
+        rel: 'self',
+        title: 'Info about this collection',
+        type: 'application/json'
+      }
+    ],
+    data_center: 'USA',
+    points: ['39,77']
+  }];
+
+  const event = { headers: { Host: 'example.com' }, queryStringParameters: [] };
+
+  it('should return a cmrGranule to a FeatureCollection', () => {
+    expect(cmrGranulesToFeatureCollection(event, cmrGran)).toEqual({
+      type: 'FeatureCollection',
+      features: [{
+        id: 1,
+        geometry: { type: 'Point', coordinates: [77, 39] },
+        properties: {
+          provider: 'USA',
+          datetime: '0/1'
+        },
+        type: 'Feature',
+        assets: {},
+        links: {
+          self: {
+            rel: 'self',
+            href: 'http://example.com/collections/10/items/1'
+          },
+          parent: {
+            rel: 'parent',
+            href: 'http://example.com/collections/10'
+          },
+          metadata: {
+            href: 'https://cmr.earthdata.nasa.gov/search/concepts/1.native',
+            rel: 'metadata',
+            type: 'application/json',
+            title: undefined
+          }
+        }
+      }],
+      links: {
+        self: 'http://example.com/undefined?',
+        next: 'http://example.com/undefined?page_num=2'
+      }
+    });
+  });
+});

--- a/search/tests/convert/collections.spec.js
+++ b/search/tests/convert/collections.spec.js
@@ -106,7 +106,6 @@ describe('collections', () => {
   });
 
   describe('cmrGranuleSearchWithCurrentParams', () => {
-    //queryStringParameters, collectionId, provider, headers(host), 
     const collID = 'landsat-8-l1';
     const event = {
       queryStringParameters: {
@@ -122,10 +121,8 @@ describe('collections', () => {
     });
 
     it('should return a CMR search url without any parameters', () => {
-      console.log(cmrGranuleSearchWithCurrentParams(otherEvent, collID));
       expect(cmrGranuleSearchWithCurrentParams(otherEvent, collID)).toEqual('https://cmr.earthdata.nasa.gov/search/granules.json?collection_concept_id=landsat-8-l1');
     });
-    
   });
 
   describe('cmrCollToWFSCol', () => {

--- a/search/tests/convert/collections.spec.js
+++ b/search/tests/convert/collections.spec.js
@@ -1,60 +1,43 @@
-const { cmrGranulesToFeatureCollection } = require('../../lib/convert');
+const { 
+  cmrCollSpatialToExtents,
+  stacSearchWithCurrentParams,
+  cmrGranulesSearchWithCurrentParams,
+  cmrCollToWFSColl
+} = require('../../lib/convert/collections');
 
-describe('cmrGranulesToFeatureCollection', () => {
-  const cmrGran = [{
-    id: 1,
-    collection_concept_id: 10,
-    dataset_id: 'datasetId',
-    summary: 'summary',
-    time_start: 0,
-    time_end: 1,
-    links: [
-      {
-        href: 'http://example.com/collections/id',
-        rel: 'self',
-        title: 'Info about this collection',
-        type: 'application/json'
+describe('collections', () => {
+  describe('cmrCollSpatialToExtents', () => {
+    // four scenarios need to be tested. The cmrColl object having either polygons, 
+    // points, lines, boxes, or nothing.
+    let cmrCollection;
+
+    it('should return a bounding box from given polygon', () => {
+      cmrCollection = {
+        polygons: [['30 -10 70 33 -45 66']]
+      };
+      expect(cmrCollSpatialToExtents(cmrCollection)).toEqual([-10, 70, 66, -45]);
+    });
+
+    it('should return a bounding box from given points', () => {
+      cmrCollection = {
+        points: ['30 -10', '70 33', '-45 66']
+      };
+      expect(cmrCollSpatialToExtents(cmrCollection)).toEqual([-10, 70, 66, -45]);
+    });
+
+    it('should throw an error if given lines', () => {
+      cmrCollection = {
+        id: 'sampleCollection',
+        lines: [28.2, 44, -44, 109.3]
       }
-    ],
-    data_center: 'USA',
-    points: ['39,77']
-  }];
+      expect(() => { cmrCollSpatialToExtents(cmrCollection); }).toThrow(Error);
+    });
 
-  const event = { headers: { Host: 'example.com' }, queryStringParameters: [] };
-
-  it('should return a cmrGranule to a FeatureCollection', () => {
-    expect(cmrGranulesToFeatureCollection(event, cmrGran)).toEqual({
-      type: 'FeatureCollection',
-      features: [{
-        id: 1,
-        geometry: { type: 'Point', coordinates: [77, 39] },
-        properties: {
-          provider: 'USA',
-          datetime: '0/1'
-        },
-        type: 'Feature',
-        assets: {},
-        links: {
-          self: {
-            rel: 'self',
-            href: 'http://example.com/collections/10/items/1'
-          },
-          parent: {
-            rel: 'parent',
-            href: 'http://example.com/collections/10'
-          },
-          metadata: {
-            href: 'https://cmr.earthdata.nasa.gov/search/concepts/1.native',
-            rel: 'metadata',
-            type: 'application/json',
-            title: undefined
-          }
-        }
-      }],
-      links: {
-        self: 'http://example.com/undefined?',
-        next: 'http://example.com/undefined?page_num=2'
-      }
+    it('should return a bounding box from provided coordinates [west north east south]', () => {
+      cmrCollection = {
+        boxes: ['-23.4 -74.6 54.9 33.3']
+      };
+      expect(cmrCollSpatialToExtents(cmrCollection)).toEqual([-23.4, -74.6, 54.9, 33.3]);
     });
   });
 });

--- a/search/tests/convert/collections.spec.js
+++ b/search/tests/convert/collections.spec.js
@@ -4,6 +4,7 @@ const {
   cmrGranulesSearchWithCurrentParams,
   cmrCollToWFSColl
 } = require('../../lib/convert/collections');
+const { WHOLE_WORLD_BBOX } = require('../../lib/convert');
 
 describe('collections', () => {
   describe('cmrCollSpatialToExtents', () => {
@@ -38,6 +39,11 @@ describe('collections', () => {
         boxes: ['-23.4 -74.6 54.9 33.3']
       };
       expect(cmrCollSpatialToExtents(cmrCollection)).toEqual([-23.4, -74.6, 54.9, 33.3]);
+    });
+
+    it('should return a bounding box containing the WHOLE_WORLD_BBOX', () => {
+      cmrCollection = {};
+      expect(cmrCollSpatialToExtents(cmrCollection)).toEqual(WHOLE_WORLD_BBOX);
     });
   });
 });


### PR DESCRIPTION
This ticket is focused on extracting code from the `cmr_converter` to a `collections` module and providing test around it.

The goal here was to extract all code that created or supported collections. To achieve this we have moved all of this code from `cmr_converter` to a `collections` file inside of the `converter` directory. We then made a few updates to the code in the `collections` file and created test around them.

We have also updated exported these modules through the `converter/index` file where they are exported as `collections`. We have also updated imports on several files.